### PR TITLE
Remove Docker build from Packer JSON

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,6 @@ FROM google/cloud-sdk
 MAINTAINER Evan Brown <evanbrown@google.com>
 
 RUN apt-get install -y curl
-RUN gcloud components update beta --quiet
 COPY . /tmp/scalable-resilient-web-app-solution
 RUN cp /tmp/scalable-resilient-web-app-solution/test/e2e.sh /tmp/scalable-resilient-web-app-solution/e2e.sh
 WORKDIR /tmp/scalable-resilient-web-app-solution

--- a/packer.json
+++ b/packer.json
@@ -13,11 +13,6 @@
       "source_image": "ubuntu-1404-trusty-v20151113",
       "zone": "us-central1-a",
       "image_name": "redmine-{{timestamp}}-{{user `git_branch`}}-{{user `git_commit`}}"
-    },
-    {
-      "type": "docker",
-      "image": "ubuntu:14.04",
-      "commit": "true" 
     }
   ],
   "provisioners": [
@@ -32,15 +27,5 @@
         "recipe[rails-sample::app]"
       ]
     }
-  ],
-  "post-processors": [
-        [
-            {
-                "type": "docker-tag",
-                "repository": "gcr.io/{{user `project_id`}}/redmine",
-                "tag": "{{user `git_branch`}}-{{user `git_commit`}}",
-                "only": ["docker"]
-            }
-        ]
-    ]
+  ]
 }


### PR DESCRIPTION
This is required for the Jenkins+Packer solution to work properly with the update Jenkins+GKE solution.